### PR TITLE
Remove helm kyverno/kyverno-crds

### DIFF
--- a/kubernetes/30-kyverno-setup.sh
+++ b/kubernetes/30-kyverno-setup.sh
@@ -21,5 +21,4 @@ kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --fr
 # Assumes helm already installed by previous scripts
 helm repo add kyverno https://kyverno.github.io/kyverno/
 helm repo update
-helm upgrade --install kyverno-crds kyverno/kyverno-crds --namespace kyverno --create-namespace
-helm upgrade --install kyverno kyverno/kyverno -n kyverno --set extraArgs="{--webhooktimeout=15,--imagePullSecrets=regcred}"
+helm upgrade --install kyverno kyverno/kyverno -n kyverno --create-namespace --set extraArgs="{--webhooktimeout=15,--imagePullSecrets=regcred}"


### PR DESCRIPTION
From the Kyverno Slack channel: “As of the 1.5.x release, you no longer need to install the CRDs separately. They’ve been brought back into the main chart.”