### PR TITLE
Execution independent reference to enable-mutating.yaml

### DIFF
--- a/platform/31-opa-gatekeeper-setup.sh
+++ b/platform/31-opa-gatekeeper-setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # Update below if you have a different config.json you want to use.
 DOCKER_CONFIG_JSON=$HOME/.docker/config.json
 
@@ -13,4 +15,4 @@ kubectl create namespace gatekeeper --dry-run=client -o yaml | kubectl apply -f 
 kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$DOCKER_CONFIG_JSON -n gatekeeper  --dry-run=client -o yaml | kubectl apply -f -
 
 helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
-helm upgrade -f enable-mutating.yaml --install gatekeeper gatekeeper/gatekeeper -n gatekeeper
+helm upgrade -f ${SCRIPT_DIR}/../resources/enable-mutating.yaml --install gatekeeper gatekeeper/gatekeeper -n gatekeeper


### PR DESCRIPTION
Make the usage of `enable-mutating.yaml` more independent of where the script is executed from.