### PR TITLE
Fix Builpacks pipeline

### DIFF
--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -1,0 +1,36 @@
+# buildpacks
+
+## How to run this demo
+
+Execute the following commands from the root of this repository:
+
+```bash
+# Only if a cluster is needed.
+make setup-minikube
+
+# Setup tekton w/ chains
+make setup-tekton-chains tekton-generate-keys
+export COSIGN_PUB=${PWD}/cosign.pub
+
+# Run a new pipeline.
+./examples/buildpacks/buildpacks.sh
+# Or re-run the last one.
+# tkn pipeline start buildpacks -L
+# Wait until it completes.
+
+# Ensure it has been signed.
+tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
+# Should output "true"
+
+# Double check that the attestation and the signature were uploaded to the OCI.
+crane ls ttl.sh/slsapoc
+
+# Verify the image and the attestation.
+export DOCKER_IMG=ttl.sh/slsapoc
+cosign verify -key $COSIGN_PUB ${DOCKER_IMG}
+cosign verify-attestation -key $COSIGN_PUB ${DOCKER_IMG}
+```
+
+## Links
+
+* Buildpacks: <https://buildpacks.io/>

--- a/examples/buildpacks/buildpacks.sh
+++ b/examples/buildpacks/buildpacks.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # Define variables.
-TOP=$(git root)
+GIT_ROOT=$(git rev-parse --show-toplevel)
 
 # Install the buildpacks pipelinerun.
-kubectl apply -f ${TOP}/resources/tekton/examples/buildpacks/pipelinerun-buildpacks.yaml
+kubectl apply -f ${GIT_ROOT}/examples/buildpacks/pipeline-pvc.yaml
+kubectl create -f ${GIT_ROOT}/examples/buildpacks/pipelinerun-buildpacks.yaml
 tkn pipelinerun describe --last

--- a/examples/buildpacks/pipeline-pvc.yaml
+++ b/examples/buildpacks/pipeline-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cache-image-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/examples/buildpacks/pipelinerun-buildpacks.yaml
+++ b/examples/buildpacks/pipelinerun-buildpacks.yaml
@@ -1,19 +1,8 @@
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: cache-image-ws-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 500Mi
----
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: cache-image-pipelinerun
+  generateName: cache-image-pipelinerun-
   labels:
     app.kubernetes.io/description: PipelineRun
 spec:

--- a/platform/10-tekton-setup.sh
+++ b/platform/10-tekton-setup.sh
@@ -32,7 +32,7 @@ wait_for_pods tekton-dashboard
 
 # Install shared tasks.
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.4/git-clone.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.3/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.4/buildpacks.yaml
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
 
 # Install shared pipeline.


### PR DESCRIPTION
Uses the latest version of the Buildpacks pipeline (0.4) since this one
is Chains compliant.

The example installer was updated to create a new pipelinerun after each
execution and some documentation was added to showcase how to use it and
what it does.
