### PR TITLE
Move chains patches to files

### DIFF
--- a/platform/11-tekton-chains.sh
+++ b/platform/11-tekton-chains.sh
@@ -16,22 +16,22 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 # Install Chains.
 kubectl apply --filename $GIT_ROOT/platform/vendor/tekton/chains/release.yaml
 
+kubectl patch \
+      configmap chains-config \
+      -n tekton-chains \
+      --patch-file $GIT_ROOT/platform/components/tekton/chains/patch_config_oci.yaml
+
 # Patch chains to generate in-toto provenance.
 case "${TKN_CHAINS_FORMAT}" in
   intoto)
     kubectl patch \
       configmap chains-config \
       -n tekton-chains \
-      -p='{"data":{"artifacts.taskrun.format": "in-toto"}}'
+      --patch-file $GIT_ROOT/platform/components/tekton/chains/patch_config_intoto.yaml
     ;;
   *)
     ;;
 esac
-
-kubectl patch \
-      configmap chains-config \
-      -n tekton-chains \
-      -p='{"data": {"artifacts.taskrun.storage": "oci", "artifacts.taskrun.format": "tekton-provenance"}}'
 
 # Install Cosign if needed.
 if ! cosign version; then

--- a/platform/components/tekton/chains/patch_config_intoto.yaml
+++ b/platform/components/tekton/chains/patch_config_intoto.yaml
@@ -1,0 +1,2 @@
+data:
+  artifacts.taskrun.format: in-toto

--- a/platform/components/tekton/chains/patch_config_oci.yaml
+++ b/platform/components/tekton/chains/patch_config_oci.yaml
@@ -1,0 +1,3 @@
+data: 
+  artifacts.taskrun.storage: oci
+  artifacts.taskrun.format: tekton-provenance


### PR DESCRIPTION
This is better than inlining it in the shell script since we can
more easily change and review the patch files. This also makes it
simpler to parameterize in the future.