### PR TITLE
Alternate approach for internal OCI registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ setup-kyverno: ## Setup Kyverno.
 setup-opa-gatekeeper: ##  Setup opa gatekeeper
 	bash platform/31-opa-gatekeeper-setup.sh
 
+.PHONY: example-buildpacks
+example-buildpacks: ## Run the buildpacks example.
+	bash examples/buildpacks/buildpacks.sh
+
 .PHONY: example-ibm-tutorial
 example-ibm-tutorial: ## Run the IBM pipeline example.
 	bash examples/ibm-tutorial/ibm-tutorial.sh

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -10,29 +10,41 @@ make setup-minikube
 
 # Setup tekton w/ chains
 make setup-tekton-chains tekton-generate-keys
-export COSIGN_PUB=${PWD}/cosign.pub
+
+#### Begin local minikube registry
+##
+## Use this section if you want to use the minikube registry for
+## publishing OCI artifacts.
+##
+## In a separate terminal, port forward the registry: defaults to <host-ip>:8888
+#  make registry-proxy
+##
+## Set the registry for use in buildpacks.sh
+#  export REGISTRY=<host-ip>:8888
+##
+#### End local minikube registry
 
 # Run a new pipeline.
-./examples/buildpacks/buildpacks.sh
+make example-buildpacks
 # Or re-run the last one.
 # tkn pipeline start buildpacks -L
 
 # Export the value of APP_IMAGE from the pipelinerun describe as DOCKER_IMG:
-export DOCKER_IMG=$(tkn pr describe --last -o json | jq -r '.spec.params[] | select(.name=="APP_IMAGE") | .value')
+export DOCKER_IMG=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="APP_IMAGE")].value}')
 
 # Wait until it completes.
 tkn pr logs --last -f
 
 # Ensure it has been signed.
-tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
+tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/signed}'
 # Should output "true"
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls ${DOCKER_IMG}
+crane ls "${DOCKER_IMG}"
 
 # Verify the image and the attestation.
-cosign verify --key $COSIGN_PUB ${DOCKER_IMG}
-cosign verify-attestation --key $COSIGN_PUB ${DOCKER_IMG}
+cosign verify --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
+cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
 ```
 
 ## Links


### PR DESCRIPTION
An alternate approach for using the minikube registry for OCI pushes and exposing it for verification via `crane` and `cosign`.