### PR TITLE
Move buildpacks task installs to the examples

### DIFF
--- a/examples/buildpacks/buildpacks.sh
+++ b/examples/buildpacks/buildpacks.sh
@@ -11,6 +11,14 @@ C_YELLOW='\033[33m'
 C_RED='\033[31m'
 C_RESET_ALL='\033[0m'
 
+# Install shared tasks.
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.4/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
+
+# Install shared pipeline.
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/buildpacks/0.1/buildpacks.yaml
+
 # Install the buildpacks pipelinerun.
 kubectl apply -f ${GIT_ROOT}/examples/buildpacks/pipeline-pvc.yaml
 

--- a/platform/10-tekton-setup.sh
+++ b/platform/10-tekton-setup.sh
@@ -29,11 +29,3 @@ wait_for_pods tekton-pipelines-controller
 #   to access it.
 kubectl apply --filename https://github.com/tektoncd/dashboard/releases/latest/download/tekton-dashboard-release.yaml
 wait_for_pods tekton-dashboard
-
-# Install shared tasks.
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
-kubectl apply -f https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.4/buildpacks.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
-
-# Install shared pipeline.
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/buildpacks/0.1/buildpacks.yaml


### PR DESCRIPTION
Long term we probably want to vendor the tasks, but this should
be a good fix for some of the timeouts we're seeing in our tests

I think this should avoid the timeouts?