### PR TITLE
ignore generated cosign.pub key generated from ocidemo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ result
 kubernetes/scripts/*.json
 kubernetes/scripts/payload
 kubernetes/scripts/signature
+
+#ignore keys
+*.pub


### PR DESCRIPTION
when running `make setup-tekton-chains tekton-generate-keys setup-kyverno`
a cosign.pub filed is generated that shouldn't be versioned.