### PR TITLE
Implement new action to publish documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -22,12 +23,11 @@ jobs:
         env:
           BUILD_DIR: docs
           BUILD_ONLY: true
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: deploy
+      - name: Deploy
         if: github.ref == 'refs/heads/main'
-        uses: shalzz/zola-deploy-action@v0.14.1
-        env:
-          BUILD_DIR: docs
-          PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public
+
 


### PR DESCRIPTION
Implements a new action to publish the documentation and avoiding the
`GITHUB_TOKEN` issue.
