### PR TITLE
added wait for kyverno

### DIFF
--- a/platform/30-kyverno-setup.sh
+++ b/platform/30-kyverno-setup.sh
@@ -20,9 +20,10 @@ C_RESET_ALL='\033[0m'
 # Wait until pods are ready.
 # $1: namespace, $2: app label
 wait_for_pods () {
-  sleep 1
+  while [[ $(kubectl get pods --namespace "$1" -l app="$2" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo -e "${C_YELLOW}Waiting: $2 pods in $1...${C_RESET_ALL}"
-  kubectl wait --timeout=5m --for=condition=ready pods -l app="$2" -n "$1"
+  sleep 1
+done
 }
 
 # Update below if you have a different config.json you want to use.
@@ -48,6 +49,7 @@ kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --fr
 ### HACK - setting to Jim's personal image repo for kyverno to resolve
 ### failed calling webhook "mutate.kyverno.svc-fail" error. Once this image
 ### is offically released, this will be removed.
+echo -e "${C_GREEN}Patching Kyverno image until release of v1.6.0...${C_RESET_ALL}"
 kubectl set image -n kyverno deploy/kyverno kyverno=ghcr.io/jimbugwadia/kyverno:v1.6.0-130-g8a0d465d
 
 echo -e "${C_GREEN}Patching Kyverno deployment...${C_RESET_ALL}"
@@ -55,6 +57,7 @@ kubectl patch \
   deployment kyverno \
   -n kyverno \
   --type json --patch-file "${GIT_ROOT}"/platform/components/kyverno/patch_container_args.json
+wait_for_pods kyverno kyverno
 
 echo -e "${C_GREEN}Creating verify-image admission control policy...${C_RESET_ALL}"
 pushd "$KYVERNO_RESOURCE_DIR"


### PR DESCRIPTION
Removed:
```
wait_for_pods () {
  echo -e "${C_YELLOW}Waiting: $2 pods in $1...${C_RESET_ALL}"
  kubectl wait --timeout=5m --for=condition=ready pods -l app=$2 -n $1
}
```
 and replaced with:
 ```
 wait_for_pods () {
  while [[ $(kubectl get pods --namespace "$1" -l app="$2" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
  echo -e "${C_YELLOW}Waiting: $2 pods in $1...${C_RESET_ALL}"
  sleep 1
done
```
As the `kubectl wait` would hang the shell script and not proceed further. Needed to add another check after the patching and image change to ensure that the kyverno has time to terminate the old pod and bring up the new patched pod. This fixes the issues with the race condition that happens sometimes when the CI brings up a new cluster. 