### PR TITLE
Fix docs build step

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: build
-        if: github.ref != 'refs/heads/main'
         uses: shalzz/zola-deploy-action@v0.14.1
         env:
           BUILD_DIR: docs


### PR DESCRIPTION
Fixes the CI step building the documentation by removing an unnecessary
condition left over from the previous GitHub action.
