### PR TITLE
Update 00-kubernetes-minikube-setup.sh

### DIFF
--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -61,7 +61,7 @@ case "${PLATFORM}" in
     kubectl version || brew install kubectl
     cosign version || brew install sigstore/tap/cosign
     cue version || brew install cuelang/tap/cue 
-    jq version || brew install jq
+    jq --version || brew install jq
     ;;
 
   Linux)


### PR DESCRIPTION
Fixes a typo in the `jq` command.