### PR TITLE
Fix usage of repository tag in examples

### DIFF
--- a/docs/content/docs/help/using-cue.md
+++ b/docs/content/docs/help/using-cue.md
@@ -60,8 +60,8 @@ commands for exporting things that can be used in conjunction with `kubectl`. An
 `examples/buildpacks/buildpacks.sh`.
 
 ```bash
-cue -t "repository=${REGISTRY}" apply ./examples/buildpacks | kubectl apply -f -
-cue -t "repository=${REGISTRY}" create ./examples/buildpacks | kubectl create -f -
+cue -t "repository=${REPOSITORY}" apply ./examples/buildpacks | kubectl apply -f -
+cue -t "repository=${REPOSITORY}" create ./examples/buildpacks | kubectl create -f -
 ```
 
 Here we are using the `cue apply ...` command to export definitions from `./examples/buildpacks`

--- a/examples/buildpacks/buildpacks.sh
+++ b/examples/buildpacks/buildpacks.sh
@@ -7,8 +7,6 @@ DEFAULT_REPOSITORY=$(xxd -l 16 -c 16 -p < /dev/random)
 : "${REGISTRY:=ttl.sh}"
 : "${REPOSITORY:=$REGISTRY/$DEFAULT_REPOSITORY}"
 C_GREEN='\033[32m'
-C_YELLOW='\033[33m'
-C_RED='\033[31m'
 C_RESET_ALL='\033[0m'
 
 # Install shared tasks.
@@ -22,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipelin
 # Install the buildpacks pipelinerun.
 echo -e "${C_GREEN}Creating a buildpacks pipelinerun: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"
 pushd "${GIT_ROOT}"
-cue -t "repository=${REGISTRY}" apply ./examples/buildpacks | kubectl apply -f -
-cue -t "repository=${REGISTRY}" create ./examples/buildpacks | kubectl create -f -
+cue -t "repository=${REPOSITORY}" apply ./examples/buildpacks | kubectl apply -f -
+cue -t "repository=${REPOSITORY}" create ./examples/buildpacks | kubectl create -f -
 popd
 tkn pipelinerun describe --last

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -76,3 +76,4 @@ deployed on the cluster
 % kubectl get pod
 NAME                                         READY   STATUS      RESTARTS   AGE
 picalc-cf9dddfdf-bnwv8                       1/1     Running     0          59m
+```

--- a/examples/sample-pipeline/sample-pipeline.sh
+++ b/examples/sample-pipeline/sample-pipeline.sh
@@ -13,7 +13,7 @@ C_RESET_ALL='\033[0m'
 # Install the sample pipeline.
 echo -e "${C_GREEN}Creating a sample-pipeline: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"
 pushd "${GIT_ROOT}"
-cue -t "repository=${REGISTRY}" apply ./examples/sample-pipeline | kubectl apply -f -
-cue -t "repository=${REGISTRY}" create ./examples/sample-pipeline | kubectl create -f -
+cue -t "repository=${REPOSITORY}" apply ./examples/sample-pipeline | kubectl apply -f -
+cue -t "repository=${REPOSITORY}" create ./examples/sample-pipeline | kubectl create -f -
 popd
 tkn pipelinerun describe --last


### PR DESCRIPTION
Fix the usage of the `repository` tag in the example pipelines.

The scripts should be using `REPOSITORY` instead of `REGISTRY` when setting the `repository` tag in the cue evaluation. The scripts are setup to automatically add a random 16-character string to the end of the `REGISTRY` value to produce a randomized `REPOSITORY`. If the user has specified the `REGISTRY` environment variable (e.g. `export REGISTRY=192.168.1.37:8888`), then the scripts will set `REPOSITORY` to a randomized value (e.g. `REPOSITORY=192.168.1.37:8888/e407c33f1a155f60e1a7504d43ae925e`). The user still has the option to specify the `REPOSITORY` value directly if the prefer to not have it randomized (e.g. `export REPOSITORY=192.168.1.37:8888`).