### PR TITLE
updated sample-pipeline and kyverno based on chains update. Added Sample-pipeline to integration test

### DIFF
--- a/.github/workflows/install-ssf.yaml
+++ b/.github/workflows/install-ssf.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Kyverno
         run: |
           make setup-kyverno
-      - name: Run test pipeline
+      - name: Run buildpacks pipeline
         run: |
           ./examples/buildpacks/buildpacks.sh
           export DOCKER_IMG=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="APP_IMAGE")].value}')
@@ -42,3 +42,20 @@ jobs:
           tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
           cosign verify --key k8s://tekton-chains/signing-secrets ${DOCKER_IMG}
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets ${DOCKER_IMG}
+      - name: Run sample pipeline to test kyverno
+        run: |
+          make example-sample-pipeline
+          export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageUrl")].value}')
+          export IMAGE_TAG=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageTag")].value}')
+          export DOCKER_IMG="${IMAGE_URL}:${IMAGE_TAG}"
+
+          tkn pr logs --last -f
+          sleep 60
+          docker run --rm gcr.io/go-containerregistry/crane ls "${IMAGE_URL}"
+
+          cosign verify --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
+          cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
+
+          kubectl wait --timeout=5m --for=condition=ready pods -l app=picalc -n prod
+
+

--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -8,7 +8,7 @@ secret: "kube-api-secret": {
 serviceAccount: "pipeline-account": {
 }
 
-role: "pipeline-role": rules: [{
+clusterRole: "pipeline-role": rules: [{
 	apiGroups: [""]
 	resources: ["services"]
 	verbs: ["get", "create", "update", "patch"]
@@ -18,14 +18,15 @@ role: "pipeline-role": rules: [{
 	verbs: ["get", "create", "update", "patch"]
 }]
 
-roleBinding: "pipeline-role-binding": {
+clusterRoleBinding: "pipeline-role-binding": {
 	roleRef: {
 		apiGroup: "rbac.authorization.k8s.io"
-		kind:     "Role"
+		kind:     "ClusterRole"
 		name:     "pipeline-role"
 	}
 	subjects: [{
 		kind: "ServiceAccount"
+		namespace: "default"
 		name: "pipeline-account"
 	}]
 }

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -57,10 +57,6 @@ export DOCKER_IMG="${IMAGE_URL}:${IMAGE_TAG}"
 # Wait until it completes.
 tkn pr logs --last -f
 
-# Ensure it has been signed.
-tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/signed}'
-# Should output "true"
-
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "${IMAGE_URL}"
 

--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -278,6 +278,8 @@ task: "deploy-using-kubectl": {
 		}, {
 			args: [
 				"apply",
+				"-n",
+				"prod",
 				"-f",
 				"$(workspaces.git-source.path)/$(params.pathToYamlFile)",
 			]

--- a/examples/sample-pipeline/sample-pipeline.sh
+++ b/examples/sample-pipeline/sample-pipeline.sh
@@ -9,6 +9,10 @@ DEFAULT_REPOSITORY=$(xxd -l 16 -c 16 -p < /dev/random)
 C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
+# Create prod namespace for deployment if it does not already exit
+kubectl create namespace prod --dry-run=client -o yaml | kubectl apply -f -
+# Create prod service account for deployment if it does not already exit
+kubectl create sa pipeline-account -n prod --dry-run=client -o yaml | kubectl apply -f -
 
 # Install the sample pipeline.
 echo -e "${C_GREEN}Creating a sample-pipeline: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"

--- a/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
@@ -4,16 +4,16 @@ AttestationClusterPolicy: "attest-code-review":
 	spec: rules: [{
 			verifyImages: [{
 				attestations: [{
-					predicateType: "https://slsa.dev/provenance/v0.1"
+					predicateType: "https://slsa.dev/provenance/v0.2"
 					conditions: [{
 						all: [{
 							key:      "{{ builder.id }}"
 							operator: "Equals"
-							value:    "tekton-chains"
+							value:    "https://tekton.dev/chains/v2"
 						}, {
-							key:      "{{ recipe.type }}"
+							key:      "{{ buildType }}"
 							operator: "Equals"
-							value:    "https://tekton.dev/attestations/chains@v1"
+							value:    "https://tekton.dev/attestations/chains@v2"
 						}]
 					}]
 				}]

--- a/ssf.cue
+++ b/ssf.cue
@@ -31,9 +31,21 @@ role: [Name=_]: k8sRbacV1.#Role & {
 	metadata: name: *Name | string
 }
 
+clusterRole: [Name=_]: k8sRbacV1.#ClusterRole & {
+	kind:       "ClusterRole"
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	metadata: name: *Name | string
+}
+
 roleBinding: [Name=_]: k8sRbacV1.#RoleBinding & {
 	apiVersion: "rbac.authorization.k8s.io/v1"
 	kind:       "RoleBinding"
+	metadata: name: *Name | string
+}
+
+clusterRoleBinding: [Name=_]: k8sRbacV1.#ClusterRoleBinding & {
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	kind:       "ClusterRoleBinding"
 	metadata: name: *Name | string
 }
 

--- a/ssf_tool.cue
+++ b/ssf_tool.cue
@@ -9,6 +9,8 @@ applySets: [
 	secret,
 	serviceAccount,
 	role,
+	clusterRole,
+	clusterRoleBinding,
 	roleBinding,
 	persistentVolumeClaim,
 	pipeline,


### PR DESCRIPTION
Updated the sample-pipeline such that it can be deployed into the `prod` namespace. The Kyverno attestation checker policy will check that the image is signed and the provenance format matches. The integration test will help ensure that kyverno policy is always tested in each PR.