### PR TITLE
Revert "Update Tekton Pipeline to v0.32.1 (#128)"

### DIFF
--- a/platform/vendor/tekton/pipeline/release.yaml
+++ b/platform/vendor/tekton/pipeline/release.yaml
@@ -42,15 +42,9 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 spec:
   privileged: false
   allowPrivilegeEscalation: false
-  requiredDropCapabilities:
-    - ALL
   volumes:
     - 'emptyDir'
     - 'configMap'
@@ -60,11 +54,6 @@ spec:
   hostPID: false
   runAsUser:
     rule: 'MustRunAsNonRoot'
-  runAsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      - min: 1
-        max: 65535
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
@@ -128,14 +117,10 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # Read-write access to create Pods and PVCs (for Workspaces)
+  # Read-write access to create Pods, K8s Events and PVCs (for Workspaces)
   - apiGroups: [""]
-    resources: ["pods", "persistentvolumeclaims"]
+    resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  # Write permissions to publish events.
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "update", "patch"]
   # Read-only access to these.
   - apiGroups: [""]
     resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]
@@ -154,24 +139,11 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # The webhook needs to be able to get and update customresourcedefinitions,
+  # The webhook needs to be able to list and update customresourcedefinitions,
   # mainly to update the webhook certificates.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
-    verbs: ["get", "update", "patch"]
-    resourceNames:
-      - pipelines.tekton.dev
-      - pipelineruns.tekton.dev
-      - runs.tekton.dev
-      - tasks.tekton.dev
-      - clustertasks.tekton.dev
-      - taskruns.tekton.dev
-      - pipelineresources.tekton.dev
-      - conditions.tekton.dev
-  # knative.dev/pkg needs list/watch permissions to set up informers for the webhook.
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["list", "watch"]
+    verbs: ["get", "list", "update", "patch", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     # The webhook performs a reconciliation on these two resources and continuously
     # updates configuration.
@@ -546,8 +518,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -626,8 +598,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   versions:
@@ -679,8 +651,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -759,8 +731,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -868,8 +840,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   versions:
@@ -921,8 +893,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -988,8 +960,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1068,8 +1040,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
-    version: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1179,7 +1151,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
 # The data is populated at install time.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -1190,7 +1162,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1209,7 +1181,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1228,7 +1200,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1579,7 +1551,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v0.32.1"
+  version: "v0.29.0"
 
 ---
 # Copyright 2020 Tekton Authors LLC
@@ -1777,12 +1749,12 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.32.1"
+    version: "v0.29.0"
 spec:
   replicas: 1
   selector:
@@ -1797,13 +1769,13 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.32.1"
+        app.kubernetes.io/version: "v0.29.0"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.32.1"
+        pipeline.tekton.dev/release: "v0.29.0"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-controller
-        version: "v0.32.1"
+        version: "v0.29.0"
     spec:
       affinity:
         nodeAffinity:
@@ -1817,20 +1789,24 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
         - name: tekton-pipelines-controller
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.32.1@sha256:077cdb806e2e4f2d787066fa426e3f5c57371b5552f777e323b56c68c00f9af0
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.29.0@sha256:72f79471f06d096cc53e51385017c9f0f7edbc87379bf415f99d4bd11cf7bc2b
           args: [
             # These images are built on-demand by `ko resolve` and are replaced
             # by image references by digest.
-            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.32.1@sha256:fc663b53693f55592e9639f1b65132cce002f1b50329389524740c32cc314bc3", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.32.1@sha256:02ffc8b09e575d1ee8cfcc5a82263cea56f3f5fe04ea1082bb06d98b5b83d5e4", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.32.1@sha256:adf4bebbb80953561764a3fd65a83dc060387aadbde02e175aecf5e857b4fde7", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.32.1@sha256:ca21b9d74c05eb94a4059468e0eb794f3b6b8c4f0cf6b1cb6916251adda47ec2", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.32.1@sha256:3c4918e581ba5b67db9838ee384012e419eda8fdcd716447d588c33c7073d07b", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.32.1@sha256:62c11e60e8d4653a4eab9118e6f761fa7efe3a69e829f8c68d6ebbeb16aaf336",
+            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.29.0@sha256:6d058f2203b9ab66f538cb586c7dc3b7cc31ae958a4135dd99e51799f24b06c9", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0@sha256:c0b0ed1cd81090ce8eecf60b936e9345089d9dfdb6ebdd2fd7b4a0341ef4f2b9", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.29.0@sha256:66958b78766741c25e31954f47bc9fd53eaa28263506b262bf2cc6df04f18561", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.29.0@sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.29.0@sha256:e38dd0d32253fce5aaf1e501c0bc71facc3720564b7e97055921cc5390d612e0", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.29.0@sha256:d28202fb8b33a1d4c05f261ef8dcbcdcf3b469887d4dad256ce91f73c917420e",
             # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
             "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
             # The shell image must be root in order to create directories and copy files to PVCs.
-            # gcr.io/distroless/base:debug as of October 21, 2021
+            # gcr.io/distroless/base:debug as of Apirl 17, 2021
             # image shall not contains tag, so it will be supported on a runtime like cri-o
-            "-shell-image", "gcr.io/distroless/base@sha256:cfdc553400d41b47fd231b028403469811fcdbc0e69d66ea8030c5a0b5fbac2b",
+            "-shell-image", "gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4",
             # for script mode to work with windows we need a powershell image
             # pinning to nanoserver tag as of July 15 2021
-            "-shell-image-win", "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"]
+            "-shell-image-win", "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6",
+            # Experimental. Uncomment below to disable TaskRun and PipelineRun
+            # reconcilers' built-in taskRef and pipelineRef resolution procedures.
+            # "-experimental-disable-in-tree-resolution",
+          ]
           volumeMounts:
             - name: config-logging
               mountPath: /etc/config-logging
@@ -1883,10 +1859,6 @@ spec:
             runAsUser: 65532
             runAsGroup: 65532
           ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
             - name: probes
               containerPort: 8080
           livenessProbe:
@@ -1920,13 +1892,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v0.32.1"
+    version: "v0.29.0"
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:
@@ -1935,9 +1907,6 @@ spec:
       port: 9090
       protocol: TCP
       targetPort: 9090
-    - name: http-profiling
-      port: 8008
-      targetPort: 8008
     - name: probes
       port: 8080
   selector:
@@ -1970,12 +1939,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.32.1"
+    version: "v0.29.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -2016,12 +1985,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.32.1"
+    version: "v0.29.0"
 spec:
   replicas: 1
   selector:
@@ -2036,13 +2005,13 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.32.1"
+        app.kubernetes.io/version: "v0.29.0"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.32.1"
+        pipeline.tekton.dev/release: "v0.29.0"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-webhook
-        version: "v0.32.1"
+        version: "v0.29.0"
     spec:
       affinity:
         nodeAffinity:
@@ -2069,7 +2038,7 @@ spec:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.32.1@sha256:3e9beebdc80184231a9e147b20b9e8f15e7445af9b0e05dc6f05ce396c1f8500
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.29.0@sha256:46d5b90a7f4e9996351ad893a26bcbd27216676ad4d5316088ce351fb2c2c3dd
           # Resource request required for autoscaler to take any action for a metric
           resources:
             requests:
@@ -2141,13 +2110,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.32.1"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v0.32.1"
+    version: "v0.29.0"
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -1,8 +1,8 @@
 files:
-  - release_file: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.32.1/release.yaml"
-    rekor_uuid: "8c2e27167de31362c190107f800050cd62d79621f7305da224b25d52e9e9039e"
+  - release_file: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.29.0/release.yaml"
+    rekor_uuid: "8ba5dcc45b9fad4d879a8b6815cdaa85fdee1d9fc24cf8811f103d537c602908"
     destination_dir: "tekton/pipeline"
-    version: "v0.32.1"
+    version: "v0.29.0"
     validation_type: "rekor"
   - release_file: "https://storage.googleapis.com/tekton-releases/chains/previous/v0.8.0/release.yaml"
     sha256: "6094ce72421111d66ea7e3a2e10293db9b373abf8c0049306f76f98038e85a64"


### PR DESCRIPTION
Revert to Tekton Pipeline v0.29.0 at least until the fix for https://github.com/tektoncd/pipeline/issues/4548 (https://github.com/tektoncd/pipeline/pull/4550) is released.

This reverts commit 2a737ed2bb7d35e4691dd66f3d82d10d7d8fba9f.