### PR TITLE
Finalize the double storage tutorial

### DIFF
--- a/examples/buildpacks/dual-storage-backend.md
+++ b/examples/buildpacks/dual-storage-backend.md
@@ -80,11 +80,13 @@ tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/p
 tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-taskrun-$TASKRUN_UID}" | base64 -d | jq
 ```
 
-Verify annotations with cosign:
+Verify the attestation with cosign 1.5.1+:
 
-_In progress - see
-[tektoncd/chains#329](https://github.com/tektoncd/chains/issues/329),
-[sigstore/cosign#1321](https://github.com/sigstore/cosign/issues/1321)_.
+```bash
+tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-taskrun-$TASKRUN_UID}" | base64 -d > sig
+cosign verify-blob --key k8s://tekton-chains/signing-secrets --signature sig sig
+# Should output `Verified OK`
+```
 
 ## Advanced concepts
 

--- a/ssf-words.txt
+++ b/ssf-words.txt
@@ -13,7 +13,6 @@ CNCF's
 Configmap
 configmap
 cuelang
-# customised
 cyclonedx
 daemonset
 docdb
@@ -24,7 +23,6 @@ elif
 entryid
 gitsecure
 GOARCH
-# Implemeting
 jimbugwadia
 jsonpath
 kaniko
@@ -51,7 +49,6 @@ openshift
 Parametrizing
 picalc
 pipelinerun
-# pipepline
 pkgs
 QUICKSTART
 Quickstart


### PR DESCRIPTION
The double storage tutorial was missing the piece explaining how to
use cosign to verify the attestation stored in a task run. This new
feature was added in cosign 1.5.1 which allowed me to finalize the
tutorial.
