### PR TITLE
Make the examples more consistent

### DIFF
--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -86,8 +86,7 @@ tkn pr logs --last -f
 We start by defining some variables to simplify the validation commands:
 
 ```bash
-IMAGE_URL=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageUrl")].value}')
-export IMAGE_URL=localhost:8888${IMAGE_URL#"registry.kube-system.svc.cluster.local"}
+export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageUrl")].value}')
 export IMAGE_TAG=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageTag")].value}')
 export DOCKER_IMG="${IMAGE_URL}:${IMAGE_TAG}"
 ```

--- a/examples/buildpacks/buildpacks.cue
+++ b/examples/buildpacks/buildpacks.cue
@@ -18,6 +18,12 @@ pipelineRun: "cache-image-pipelinerun-": spec: {
 		name:  "APP_IMAGE"
 		value: _APP_IMAGE
 	}, {
+		name:  "imageUrl"
+		value: _APP_IMAGE
+	}, {
+		name:  "imageTag"
+		value: "latest"
+	}, {
 		name:  "SOURCE_URL"
 		value: "https://github.com/buildpacks/samples"
 	}, {

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -9,17 +9,26 @@ make setup-minikube
 # Setup tekton w/ chains
 make setup-tekton-chains tekton-generate-keys setup-kyverno
 
-## In a separate terminal, port forward the registry: defaults to localhost:8888
+#### Begin local minikube registry
+##
+## Use this section if you want to use the minikube registry for
+## publishing OCI artifacts.
+##
+## In a separate terminal, port forward the registry: defaults to <host-ip>:8888
 #  make registry-proxy
+##
+## Set the registry for use in buildpacks.sh
+#  export REGISTRY=<host-ip>:8888
+##
+#### End local minikube registry
 
 # Run a new pipeline.
 make example-ibm-tutorial
 # Or re-run the last one.
 # tkn pipeline start build-and-deploy-pipeline -L
 
-# Export name of the docker image from the pipelinerun as DOCKER_IMG:
-IMAGE_URL=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageUrl")].value}')
-export IMAGE_URL=localhost:8888${IMAGE_URL#"registry.kube-system.svc.cluster.local"}
+# Export the value of imageUrl from the pipelinerun describe as DOCKER_IMG:
+export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageUrl")].value}')
 export IMAGE_TAG=$(tkn pr describe --last -o jsonpath='{.spec.params[?(@.name=="imageTag")].value}')
 export DOCKER_IMG="${IMAGE_URL}:${IMAGE_TAG}"
 

--- a/examples/ibm-tutorial/ibm-tutorial.cue
+++ b/examples/ibm-tutorial/ibm-tutorial.cue
@@ -1,5 +1,9 @@
 package ssf
 
+_image: {
+	name: "picalc"
+}
+
 pipeline: "build-and-deploy-pipeline": spec: {
 	workspaces: [{
 		name:        "git-source"
@@ -80,10 +84,10 @@ pipelineRun: "picalc-pr-": spec: {
 		value: "kubernetes/picalc.yaml"
 	}, {
 		name:  "imageUrl"
-		value: "registry.kube-system.svc.cluster.local/citi/picalc"
+		value: _APP_IMAGE
 	}, {
 		name:  "imageTag"
-		value: "1.0"
+		value: "1h"
 	}]
 	serviceAccountName: "pipeline-account"
 	workspaces: [{

--- a/examples/ibm-tutorial/ibm-tutorial.sh
+++ b/examples/ibm-tutorial/ibm-tutorial.sh
@@ -3,15 +3,18 @@ set -euo pipefail
 
 # Define variables.
 GIT_ROOT=$(git rev-parse --show-toplevel)
+DEFAULT_REPOSITORY=$(xxd -l 16 -c 16 -p < /dev/random)
+: "${REGISTRY:=ttl.sh}"
+: "${REPOSITORY:=$REGISTRY/$DEFAULT_REPOSITORY}"
 C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
 # Create the IBM tutorial pipelinerun.
-echo -e "${C_GREEN}Creating a IBM tutorial pipelinerun...${C_RESET_ALL}"
+echo -e "${C_GREEN}Creating a IBM tutorial pipelinerun: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/kaniko/kaniko.yaml
 pushd "${GIT_ROOT}"
-cue apply ./examples/ibm-tutorial | kubectl apply -f -
-cue create ./examples/ibm-tutorial | kubectl create -f -
+cue -t "repository=${REPOSITORY}" apply ./examples/ibm-tutorial | kubectl apply -f -
+cue -t "repository=${REPOSITORY}" create ./examples/ibm-tutorial | kubectl create -f -
 popd
 tkn pipelinerun describe --last


### PR DESCRIPTION
- Change `ibm-tutorial` to use the same repository setting scheme as the other examples
- Allow the instructions in the quick start guide to work for all the examples, including `buildpacks`